### PR TITLE
New line case for paragraph/inlines

### DIFF
--- a/Sources/MarkdownText/Helpers/InlineStyle.swift
+++ b/Sources/MarkdownText/Helpers/InlineStyle.swift
@@ -13,7 +13,9 @@ struct InlineMarkdownConfiguration {
 
         var body: some View {
             elements.reduce(into: Text("")) { result, component in
-                if component.attributes.contains(.code) {
+                if component.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    return result = result + Text("\n")
+                } else if component.attributes.contains(.code) {
                     return result = result + code.makeBody(
                         configuration: .init(code: component.content, font: font)
                     )


### PR DESCRIPTION
Issue #6 

## Describe your changes

A simple fix for a specific case of detecting new lines. 

In these examples, when I discovered this issue, I requested a haiku from ChatGPT's api via their  `/completions` endpoint.

Screenshot example before the change:

![Screen Shot 2023-05-09 at 11 36 46 PM](https://github.com/shaps80/MarkdownText/assets/89366826/19b85142-56af-41d5-b7a6-9e008947311c)

Screenshot example after the change:

![Screen Shot 2023-05-09 at 11 38 20 PM](https://github.com/shaps80/MarkdownText/assets/89366826/78135d34-f152-4b7c-b724-e6d2c58750bd)

The ascii value of that string seems to be `32` which is just a Space/SP. 

