### PR TITLE
feat - would like to have markdownCodeSyntaxHighlighter to support

### DIFF
--- a/Sources/MarkdownText/Styles/Block Elements/CodeStyle.swift
+++ b/Sources/MarkdownText/Styles/Block Elements/CodeStyle.swift
@@ -18,35 +18,38 @@ public struct CodeMarkdownConfiguration {
 
     struct Label: View {
         @Environment(\.font) private var font
+        @Environment(\.markdownCodeSyntaxHighlighter) private var markdownCodeSyntaxHighlighter
 
         let code: String
         let language: String?
 
         var body: some View {
+            let text = markdownCodeSyntaxHighlighter
+                    .highlightCode(code.trimmingCharacters(in: .newlines), language: language)
             #if os(macOS)
             if #available(macOS 12, *) {
-                Text(code.trimmingCharacters(in: .newlines))
+                text
                     .font(
                         font?.monospaced()
                         ?? .system(.body, design: .monospaced)
                     )
             } else {
-                Text(code.trimmingCharacters(in: .newlines))
+                text
                     .font(.system(.body, design: .monospaced))
             }
             #elseif os(iOS)
             if #available(iOS 15, *) {
-                Text(code.trimmingCharacters(in: .newlines))
+                text
                     .font(
                         font?.monospaced()
                             ?? .system(.body, design: .monospaced)
                     )
             } else {
-                Text(code.trimmingCharacters(in: .newlines))
+                text
                     .font(.system(.body, design: .monospaced))
             }
             #else
-            Text(code.trimmingCharacters(in: .newlines))
+            text
                 .font(.system(.body, design: .monospaced))
             #endif
         }

--- a/Sources/MarkdownText/Styles/Block Elements/CodeSyntaxHighlighterStyle.swift
+++ b/Sources/MarkdownText/Styles/Block Elements/CodeSyntaxHighlighterStyle.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// A type that applies a custom highlighter to code block
+public protocol MarkdownCodeSyntaxHighlighterStyle {
+    func highlightCode(_ code: String, language: String?) -> Text
+}
+
+
+/// A plain text code syntax highlighter.
+public struct PlainTextCodeSyntaxHighlighterStyle: MarkdownCodeSyntaxHighlighterStyle {
+
+    public func highlightCode(_ code: String, language: String?) -> Text {
+        Text(code)
+    }
+}
+
+extension MarkdownCodeSyntaxHighlighterStyle where Self == PlainTextCodeSyntaxHighlighterStyle {
+    /// A plain text code syntax highlighter.
+    public static var plainText: Self {
+        PlainTextCodeSyntaxHighlighterStyle()
+    }
+}
+
+public extension View {
+    /// Sets the style for code block markdown elements
+    func markdownCodeSyntaxHighlighter(_ style: some MarkdownCodeSyntaxHighlighterStyle) -> some View {
+        environment(\.markdownCodeSyntaxHighlighter, style)
+    }
+}
+
+private struct MarkdownCodeSyntaxHighlighterEnvironmentKey: EnvironmentKey {
+    static let defaultValue: any MarkdownCodeSyntaxHighlighterStyle = PlainTextCodeSyntaxHighlighterStyle()
+}
+
+public extension EnvironmentValues {
+    /// The current code block highlighter style
+    var markdownCodeSyntaxHighlighter: any MarkdownCodeSyntaxHighlighterStyle {
+        get { self[MarkdownCodeSyntaxHighlighterEnvironmentKey.self] }
+        set { self[MarkdownCodeSyntaxHighlighterEnvironmentKey.self] = newValue }
+    }
+}


### PR DESCRIPTION
fix: would like to have markdownCodeSyntaxHighlighter to support #9

I can customize the HighlighterStyle using the code below:
```
import MarkdownText
import Splash
import SwiftUI
import Highlightr

struct SplashCodeSyntaxHighlighter: MarkdownCodeSyntaxHighlighterStyle {
    private let syntaxHighlighter: Highlightr


    init(theme: Splash.Theme) {
        syntaxHighlighter = Highlightr()!
        syntaxHighlighter.setTheme(to: "darcula")
    }

    func highlightCode(_ content: String, language: String?) -> Text {
        let text = syntaxHighlighter.highlight(content, as: language) ?? NSAttributedString(string: "")
        return Text(AttributedString(text))
    }
}

extension MarkdownCodeSyntaxHighlighterStyle where Self == SplashCodeSyntaxHighlighter {
    static func splash(theme: Splash.Theme) -> Self {
        SplashCodeSyntaxHighlighter(theme: theme)
    }
}
```

To use it, you can follow this example:
```
MarkdownText(message)
            .textSelection(.enabled)
            .markdownCodeSyntaxHighlighter(.splash(theme: codeTheme(scheme: colorScheme)))
```

How it's looks like:
<img width="726" alt="image" src="https://github.com/shaps80/MarkdownText/assets/1201118/a60960db-2b6f-44b7-8bd1-d72ce28619b9">


